### PR TITLE
fix: prevent useToast listener duplication

### DIFF
--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -171,7 +171,11 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // We only want to register the listener once on mount. Including `state`
+    // in the dependency array would add a new listener on every state change
+    // which leads to multiple duplicated callbacks and potential memory leaks.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid accumulating multiple listeners in useToast
- document effect intent to avoid memory leaks

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68912fecd0fc83309e7c4ccceca64ff2