### PR TITLE
chore: adjust todo label spacing

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -235,7 +235,7 @@ export default function DashboardPage() {
                       onClick={() => moveNote(note.id, 'todo')}
                       className="text-[#ff0000] hover:text-[#ffffff]"
                     >
-                      [←TODO]
+                      [← TODO]
                     </button>
                     <button
                       onClick={() => moveNote(note.id, 'done')}
@@ -272,7 +272,7 @@ export default function DashboardPage() {
                       onClick={() => moveNote(note.id, 'todo')}
                       className="text-[#ff0000] hover:text-[#ffffff]"
                     >
-                      [←TODO]
+                      [← TODO]
                     </button>
                     <button
                       onClick={() => moveNote(note.id, 'in-progress')}


### PR DESCRIPTION
## Summary
- improve readability of back-to-todo buttons on Kanban board

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts `Geist` and `Geist Mono`)*


------
https://chatgpt.com/codex/tasks/task_e_68913162a38c833091e0f8d94ddfc7ac