### PR TITLE
style: center dashboard layout

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -116,8 +116,8 @@ export default function DashboardPage() {
   };
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a] p-4">
-      <div className="max-w-7xl mx-auto px-4">
+    <div className="min-h-screen bg-[#0a0a0a] px-6 flex justify-center">
+      <div className="w-full max-w-screen-xl">
       {/* Terminal Header */}
       <div className="bg-[#1a1a1a] border border-[#00ff00] rounded-t-lg">
         <div className="bg-[#00ff00] text-[#0a0a0a] px-3 py-2 font-mono font-bold text-sm">
@@ -181,7 +181,7 @@ export default function DashboardPage() {
       </div>
 
       {/* Kanban Columns */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 mt-6 max-w-6xl mx-auto">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {/* TODO Column */}
         <div className="bg-[#1a1a1a] border border-[#ff0000] rounded">
           <div className="bg-[#ff0000] text-[#ffffff] px-4 py-2 font-mono font-bold">


### PR DESCRIPTION
## Summary
- center dashboard content with flex container and max width wrapper
- simplify kanban grid to responsive 1/2/3 column layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test test/dashboardLayout.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68923e6793d48330b2daac1b09b849f7